### PR TITLE
Allow for reddit native context parameter when requesting comments

### DIFF
--- a/reddift/Network/Session+listings.swift
+++ b/reddift/Network/Session+listings.swift
@@ -42,10 +42,11 @@ extension Session {
     - parameter depth: The maximum depth of subtrees in the thread. Default is nil.
     - parameter limit: The maximum number of comments to return. Default is nil.
     - parameter completion: The completion handler to call when the load request is complete.
+    - paramater context: Number of context comments to show (in a url looks like ?context=5)
     - returns: Data task which requests search to reddit.com.
      */
     @discardableResult
-    public func getArticles(_ link: Link, sort: CommentSort, comments: [String]? = nil, depth: Int? = nil, limit: Int? = nil, completion: @escaping (Result<(Listing, Listing)>) -> Void) throws -> URLSessionDataTask {
+    public func getArticles(_ link: Link, sort: CommentSort, comments: [String]? = nil, depth: Int? = nil, limit: Int? = nil, context:Int? = nil, completion: @escaping (Result<(Listing, Listing)>) -> Void) throws -> URLSessionDataTask {
         var parameter = ["sort":sort.type, "showmore":"True"]
         if let depth = depth {
             parameter["depth"] = "\(depth)"
@@ -57,6 +58,9 @@ extension Session {
             let commaSeparatedIDString = comments.joined(separator: ",")
             parameter["comment"] = commaSeparatedIDString
         }
+        if let context = context {
+			parameter["context"] = String(context)
+		}
         guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/comments/" + link.id + ".json", parameter:parameter, method:"GET", token:token)
             else { throw ReddiftError.canNotCreateURLRequest as NSError }
         let closure = {(data: Data?, response: URLResponse?, error: NSError?) -> Result<(Listing, Listing)> in


### PR DESCRIPTION
You can see the difference context makes between https://www.reddit.com/r/ProgrammerHumor/comments/5kxw4b/autoexecbat/dbrovj9/

and

https://www.reddit.com/r/ProgrammerHumor/comments/5kxw4b/autoexecbat/dbrovj9/?context=2

This lets us limit the amount of data we receive back from the API in a very nice, reddit based way. If you don't include a context (nil) then the function performs as previously expected.