### PR TITLE
Add stickied comment support

### DIFF
--- a/reddift/Model/Comment.swift
+++ b/reddift/Model/Comment.swift
@@ -254,6 +254,7 @@ public struct Comment: Thing {
         modReports = link.modReports
         numReports = link.numReports
         ups = link.ups
+	stickied = false
     }
     
     /**

--- a/reddift/Model/Comment.swift
+++ b/reddift/Model/Comment.swift
@@ -167,6 +167,10 @@ public struct Comment: Thing {
     example: 1
     */
     public let ups: Int
+    /**
+	   if the comment is stickied
+   	*/
+   	public let  stickied:Bool
     
     public var isExpandable: Bool {
         get {
@@ -214,6 +218,7 @@ public struct Comment: Thing {
         modReports = []
         numReports = 0
         ups = 0
+        stickied = false
     }
     
     public init(link: Link) {
@@ -293,6 +298,7 @@ public struct Comment: Thing {
         modReports = []
         numReports = data["num_reports"] as? Int ?? 0
         ups = data["ups"] as? Int ?? 0
+        stickied = data["stickied"] as? Bool ?? false
         if let temp = data["replies"] as? JSONDictionary {
             if let obj = Parser.redditAny(from: temp) as? Listing {
                 replies = obj


### PR DESCRIPTION
Reddit API supports stickied comments like for example this 

https://www.reddit.com/r/pcmasterrace/comments/5kxo86/i_went_to_visit_valves_offices_today_2017_is/dbrgvvk/

This is important because distinction between moderator forced top comments and natural top comments is vital to comment voting structure.