### PR TITLE
Update 'distinguished' field on Comments and Links to match Reddit API

### DIFF
--- a/framework/Model/Comment.swift
+++ b/framework/Model/Comment.swift
@@ -154,7 +154,7 @@ public struct Comment: Thing, Created, Votable {
     /**
     example:
     */
-    public let distinguished: Bool
+    public let distinguished: DistinguishType
     /**
     example: []
     */
@@ -215,7 +215,7 @@ public struct Comment: Thing, Created, Votable {
         created = 0
         authorFlairText = ""
         createdUtc = 0
-        distinguished = false
+        distinguished = .none
         modReports = []
         numReports = 0
         ups = 0
@@ -296,7 +296,18 @@ public struct Comment: Thing, Created, Votable {
         created = data["created"] as? Int ?? 0
         authorFlairText = data["author_flair_text"] as? String ?? ""
         createdUtc = data["created_utc"] as? Int ?? 0
-        distinguished = data["distinguished"] as? Bool ?? false
+        
+        if let distinguishedString = data["distinguished"] as? String {
+            switch distinguishedString {
+            case "admin": distinguished = .admin
+            case "moderator": distinguished = .moderator
+            case "special": distinguished = .special
+            default: distinguished = .none
+            }
+        } else {
+            distinguished = .none
+        }
+        
         modReports = []
         numReports = data["num_reports"] as? Int ?? 0
         ups = data["ups"] as? Int ?? 0

--- a/framework/Model/Enum.swift
+++ b/framework/Model/Enum.swift
@@ -370,3 +370,13 @@ public enum VoteDirection: Int {
 	case none   =  0
 	case down   = -1
 }
+
+/**
+How a Thing is distinguished from other things.
+*/
+public enum DistinguishType {
+    case none
+    case moderator
+    case admin
+    case special
+}

--- a/framework/Model/Link.swift
+++ b/framework/Model/Link.swift
@@ -236,9 +236,10 @@ public struct Link: Thing, Created, Votable {
     */
     public let numReports: Int
     /**
-    example: false
+    How the link is distinguished from other comments.
+    example: .admin
     */
-    public let distinguished: Bool
+    public let distinguished: DistinguishType
 	
     public init(id: String) {
         self.id = id
@@ -279,7 +280,7 @@ public struct Link: Thing, Created, Votable {
         upvoteRatio = 0
         visited = false
         numReports = 0
-        distinguished = false
+        distinguished = .none
         media = Media(json: [:])
         mediaEmbed = MediaEmbed(json: [:])
         
@@ -345,7 +346,18 @@ public struct Link: Thing, Created, Votable {
         upvoteRatio = data["upvote_ratio"] as? Double ?? 0
         visited = data["visited"] as? Bool ?? false
         numReports = data["num_reports"] as? Int ?? 0
-        distinguished = data["distinguished"] as? Bool ?? false
+        
+        if let distinguishedString = data["distinguished"] as? String {
+            switch distinguishedString {
+                case "admin": distinguished = .admin
+                case "moderator": distinguished = .moderator
+                case "special": distinguished = .special
+                default: distinguished = .none
+            }
+        } else {
+            distinguished = .none
+        }
+        
         media = Media(json: data["media"] as? JSONDictionary ?? [:])
         mediaEmbed = MediaEmbed(json: data["media_embed"] as? JSONDictionary ?? [:])
         

--- a/reddift.podspec
+++ b/reddift.podspec
@@ -27,5 +27,8 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
   s.requires_arc = true
 
-  s.source_files = 'framework/*/*.swift', 'framework/vendor/Google/*.{h,m}'
+  s.source_files = [
+    'framework/*/*.swift', 
+    'framework/vendor/HTMLSpecialCharacters/Sources/HTMLSpecialCharacters.swift'
+  ]
 end


### PR DESCRIPTION
Hello, I've updated the parsing of Link and Comment objects so that they match the API definition that is currently being served by Reddit and that is defined here: https://github.com/reddit/reddit/wiki/JSON#data-structures

In addition, I updated the podspec so that the HTMLSpecialCharacters source is included in the pod target.

Please have a look and let me know if you'd like me to change anything!