### PR TITLE
Fix a bug where non-logged in accounts can't use certain list methods

### DIFF
--- a/framework/Model/Comment.swift
+++ b/framework/Model/Comment.swift
@@ -60,7 +60,7 @@ public struct Comment: Thing, Created, Votable {
     how the logged-in user has voted on the link - True = upvoted, False = downvoted, null = no vote
     example:
     */
-    public let likes: VoteDirection
+    public var likes: VoteDirection
     /**
     example: {"kind"=>"Listing", "data"=>{"modhash"=>nil, "children"=>[{"kind"=>"more", "data"=>{"count"=>0, "parent_id"=>"t1_cqfhkcb", "children"=>["cqfmmpp"], "name"=>"t1_cqfmmpp", "id"=>"cqfmmpp"}}], "after"=>nil, "before"=>nil}}
     */
@@ -73,7 +73,7 @@ public struct Comment: Thing, Created, Votable {
     true if this post is saved by the logged in user
     example: false
     */
-    public let saved: Bool
+    public var saved: Bool
     /**
     example: 0
     */
@@ -99,7 +99,7 @@ public struct Comment: Thing, Created, Votable {
     the net-score of the link.  note: A submission's score is simply the number of upvotes minus the number of downvotes. If five users like the submission and three users don't it will have a score of 2. Please note that the vote numbers are not "real" numbers, they have been "fuzzed" to prevent spam bots etc. So taking the above example, if five users upvoted the submission, and three users downvote it, the upvote/downvote numbers may say 23 upvotes and 21 downvotes, or 12 upvotes, and 10 downvotes. The points score is correct, but the vote totals are "fuzzed".
     example: 1
     */
-    public let score: Int
+    public var score: Int
     /**
     example:
     */
@@ -111,7 +111,7 @@ public struct Comment: Thing, Created, Votable {
     /**
     example: The bot has been having this problem for awhile, there have been thousands of new comments since it last worked properly, so it seems like this must be something recurring? Could it have something to do with our AutoModerator?
     */
-    public let body: String
+    public var body: String
     /**
     example: false
     */
@@ -129,7 +129,7 @@ public struct Comment: Thing, Created, Votable {
     example: &lt;div class="md"&gt;&lt;p&gt;The bot has been having this problem for awhile, there have been thousands of new comments since it last worked properly, so it seems like this must be something recurring? Could it have something to do with our AutoModerator?&lt;/p&gt;
     &lt;/div&gt;
     */
-    public let bodyHtml: String
+    public var bodyHtml: String
     /**
     subreddit of thing excluding the /r/ prefix. "pics"
     example: redditdev
@@ -172,7 +172,22 @@ public struct Comment: Thing, Created, Votable {
     /**
 	   if the comment is stickied
    	*/
-   	public let stickied: Bool
+   	public let  stickied:Bool
+	/**
+	the title of the comment's parrent post IF this object is created by the inbox
+	*/
+	public let  linkTitle:String
+	
+	/**
+	if the comment is unread in the inbox
+	*/
+	public var  new:Bool
+	
+	/**
+	if the message is a comment, then the permalink to the comment with ?context=3 appended to the end, otherwise an empty string
+	example:
+	*/
+	public let  context:String
     
     public var isExpandable: Bool {
         get {
@@ -221,6 +236,9 @@ public struct Comment: Thing, Created, Votable {
         numReports = 0
         ups = 0
         stickied = false
+		linkTitle = ""
+		new = false
+		context = ""
     }
     
     public init(link: Link) {
@@ -256,7 +274,10 @@ public struct Comment: Thing, Created, Votable {
         modReports = link.modReports
         numReports = link.numReports
         ups = link.ups
-	stickied = false
+		stickied = false
+		linkTitle = ""
+		new = false
+		context = ""
     }
     
     /**
@@ -313,6 +334,9 @@ public struct Comment: Thing, Created, Votable {
         numReports = data["num_reports"] as? Int ?? 0
         ups = data["ups"] as? Int ?? 0
         stickied = data["stickied"] as? Bool ?? false
+		linkTitle = data["link_title"] as? String ?? ""
+		new = data["new"] as? Bool ?? false
+		context = data["context"] as? String ?? ""
         if let temp = data["replies"] as? JSONDictionary {
             if let obj = Parser.redditAny(from: temp) as? Listing {
                 replies = obj

--- a/framework/Model/Link.swift
+++ b/framework/Model/Link.swift
@@ -61,7 +61,7 @@ public struct Link: Thing, Created, Votable {
     &lt;p&gt;From what I understand, comment_stream() gets the most recent comments. So if we specify the limit to be 100, it will initially get the 100 newest comment, and then constantly update to get new comments.  It seems to works appropriately for every subreddit except &lt;a href="/r/helpmefind"&gt;/r/helpmefind&lt;/a&gt;. For &lt;a href="/r/helpmefind"&gt;/r/helpmefind&lt;/a&gt;, it fetches around 30 comments, regardless of the limit.&lt;/p&gt;
     &lt;/div&gt;&lt;!-- SC_ON --&gt;
     */
-    public let selftextHtml: String
+    public var selftextHtml: String
     /**
     the raw text.  this is the unformatted text which includes the raw markup characters such as ** for bold. &lt;, &gt;, and &amp; are escaped. Empty if not present.
     example: So this is the code I ran:
@@ -71,12 +71,12 @@ public struct Link: Thing, Created, Votable {
     ---
     From what I understand, comment_stream() gets the most recent comments. So if we specify the limit to be 100, it will initially get the 100 newest comment, and then constantly update to get new comments.  It seems to works appropriately for every subreddit except /r/helpmefind. For /r/helpmefind, it fetches around 30 comments, regardless of the limit.
     */
-    public let selftext: String
+    public var selftext: String
     /**
     how the logged-in user has voted on the link - True = upvoted, False = downvoted, null = no vote
     example:
     */
-    public let likes: VoteDirection
+    public var likes: VoteDirection
     /**
     example: []
     */
@@ -121,7 +121,7 @@ public struct Link: Thing, Created, Votable {
     the net-score of the link.  note: A submission's score is simply the number of upvotes minus the number of downvotes. If five users like the submission and three users don't it will have a score of 2. Please note that the vote numbers are not "real" numbers, they have been "fuzzed" to prevent spam bots etc. So taking the above example, if five users upvoted the submission, and three users downvote it, the upvote/downvote numbers may say 23 upvotes and 21 downvotes, or 12 upvotes, and 10 downvotes. The points score is correct, but the vote totals are "fuzzed".
     example: 2
     */
-    public let score: Int
+    public var score: Int
     /**
     example:
     */
@@ -149,7 +149,7 @@ public struct Link: Thing, Created, Votable {
     /**
     example: false
     */
-    public let edited: Bool
+    public var edited: Bool
     /**
     the CSS class of the link's flair.
     example:
@@ -176,7 +176,7 @@ public struct Link: Thing, Created, Votable {
     true if this post is saved by the logged in user
     example: false
     */
-    public let saved: Bool
+    public var saved: Bool
     /**
     true if this link is a selfpost
     example: true
@@ -231,7 +231,7 @@ public struct Link: Thing, Created, Votable {
     /**
     example: false
     */
-    public let visited: Bool
+    public var visited: Bool
     /**
     example: 0
     */
@@ -241,6 +241,12 @@ public struct Link: Thing, Created, Votable {
     example: .admin
     */
     public let distinguished: DistinguishType
+	
+	/**
+	A JSON representation of this object. This is set when the object is created through JSON, which it is by this library.
+	WATCH OUT IF USING THIS MANUALLY
+	*/
+	public var JSONData: JSONDictionary?
 	
     public init(id: String) {
         self.id = id
@@ -290,6 +296,7 @@ public struct Link: Thing, Created, Votable {
         reportReasons = []
         modReports = []
         secureMediaEmbed = nil
+		JSONData = nil
     }
     
     /**
@@ -367,5 +374,6 @@ public struct Link: Thing, Created, Votable {
         reportReasons = []
         modReports = []
         secureMediaEmbed = nil
+		JSONData = data
     }
 }

--- a/framework/Model/Subreddit.swift
+++ b/framework/Model/Subreddit.swift
@@ -430,6 +430,12 @@ public struct Subreddit: SubredditURLPath, Thing, Created {
     public var path: String {
         return "/r/\(displayName)"
     }
+	
+	/**
+	A JSON representation of this object. This is set when the object is created through JSON, which it is by this library.
+	WATCH OUT IF USING THIS MANUALLY
+	*/
+	public var JSONData: JSONDictionary?
     
     public init(subreddit: String) {
         self.id = "dummy"
@@ -469,6 +475,7 @@ public struct Subreddit: SubredditURLPath, Thing, Created {
         subredditType = ""
         submissionType = ""
         userIsSubscriber = false
+		JSONData = nil
         showMedia = false
         showMediaPreview = false
         wikiEnabled = false
@@ -516,6 +523,7 @@ public struct Subreddit: SubredditURLPath, Thing, Created {
         subredditType = ""
         submissionType = ""
         userIsSubscriber = false
+		JSONData = nil
         showMedia = false
         showMediaPreview = false
         wikiEnabled = false
@@ -573,6 +581,7 @@ public struct Subreddit: SubredditURLPath, Thing, Created {
         subredditType = data["subreddit_type"] as? String ?? ""
         submissionType = data["submission_type"] as? String ?? ""
         userIsSubscriber = data["user_is_subscriber"] as? Bool ?? false
+		JSONData = data
         showMedia = data["show_media"] as? Bool ?? false
         showMediaPreview = data["show_media_preview"] as? Bool ?? false
         wikiEnabled = data["wiki_enabled"] as? Bool ?? false

--- a/framework/Network/Session+listings.swift
+++ b/framework/Network/Session+listings.swift
@@ -206,7 +206,7 @@ extension Session {
     @discardableResult
     public func getRandom(_ subreddit: Subreddit? = nil, completion: @escaping (Result<(Listing, Listing)>) -> Void) throws -> URLSessionDataTask {
         var path = "/random"
-        if let subreddit = subreddit { path = subreddit.url + "/random" }
+        if let subreddit = subreddit { path = subreddit.url + "/random.json" }
         guard let request = URLRequest.requestForOAuth(with: baseURL, path:path, method:"GET", token:token)
             else { throw ReddiftError.canNotCreateURLRequest as NSError }
         let closure = {(data: Data?, response: URLResponse?, error: NSError?) -> Result<(Listing, Listing)> in
@@ -237,7 +237,7 @@ extension Session {
             //            "sr_detail": "true",
             "show": "all",
         ])
-        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/related/" + thing.id, parameter:parameter, method:"GET", token:token)
+        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/related/" + thing.id + ".json", parameter:parameter, method:"GET", token:token)
             else { throw ReddiftError.canNotCreateURLRequest as NSError }
         let closure = {(data: Data?, response: URLResponse?, error: NSError?) -> Result<(Listing, Listing)> in
             return Result(from: Response(data: data, urlResponse: response), optional:error)
@@ -265,7 +265,7 @@ extension Session {
 //            "sr_detail": "true",
             "show": "all"
         ])
-        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/duplicates/" + thing.id, parameter:parameter, method:"GET", token:token)
+        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/duplicates/" + thing.id + ".json", parameter:parameter, method:"GET", token:token)
             else { throw ReddiftError.canNotCreateURLRequest as NSError }
         let closure = {(data: Data?, response: URLResponse?, error: NSError?) -> Result<(Listing, Listing)> in
             return Result(from: Response(data: data, urlResponse: response), optional:error)
@@ -287,7 +287,7 @@ extension Session {
     @discardableResult
     public func getLinksById(_ links: [Link], completion: @escaping (Result<Listing>) -> Void) throws -> URLSessionDataTask {
         let fullnameList = links.map({ (link: Link) -> String in link.name })
-        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/by_id/" + fullnameList.joined(separator: ","), method:"GET", token:token)
+        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/by_id/" + fullnameList.joined(separator: ",") + ".json", method:"GET", token:token)
             else { throw ReddiftError.canNotCreateURLRequest as NSError }
         let closure = {(data: Data?, response: URLResponse?, error: NSError?) -> Result<Listing> in
             return Result(from: Response(data: data, urlResponse: response), optional:error)

--- a/framework/Network/Session+subreddits.swift
+++ b/framework/Network/Session+subreddits.swift
@@ -216,12 +216,20 @@ extension Session {
      new sorts the subreddits based on their creation date, newest first.
     - parameter subredditsWhere: Chooses the order in which the subreddits are displayed among SubredditsWhere.
     - parameter paginator: Paginator object for paging.
+	- parameter limit: The maximum number of subreddits to return. Default is nil (25 subs) max w/o pagination is 100
     - parameter completion: The completion handler to call when the load request is complete.
     - returns: Data task which requests search to reddit.com.
      */
     @discardableResult
-    public func getSubreddit(_ subredditWhere: SubredditsWhere, paginator: Paginator?, completion: @escaping (Result<Listing>) -> Void) throws -> URLSessionDataTask {
-        let parameter = paginator?.dictionaryByAdding(parameters: [:])
+	public func getSubreddit(_ subredditWhere: SubredditsWhere, paginator: Paginator?, limit: Int? = nil, completion: @escaping (Result<Listing>) -> Void) throws -> URLSessionDataTask {
+		var parameter = paginator?.dictionaryByAdding(parameters: [:])
+		if let limit = limit {
+			if parameter != nil {
+				parameter!["limit"] = "\(limit)"
+			}else {
+				parameter = ["limit" : "\(limit)"]
+			}
+		}
         guard let request = URLRequest.requestForOAuth(with: baseURL, path:subredditWhere.path, parameter:parameter, method:"GET", token:token)
             else { throw ReddiftError.canNotCreateURLRequest as NSError }
         let closure = {(data: Data?, response: URLResponse?, error: NSError?) -> Result<Listing> in
@@ -249,12 +257,17 @@ extension Session {
     
     - parameter mine: The type of relationship with the user as SubredditsMineWhere.
     - parameter paginator: Paginator object for paging contents.
+	- parameter limit: The maximum number of subreddits to return. Default is nil (25 subs) max w/o pagination is 100
     - parameter completion: The completion handler to call when the load request is complete.
     - returns: Data task which requests search to reddit.com.
      */
     @discardableResult
-    public func getUserRelatedSubreddit(_ mine: SubredditsMineWhere, paginator: Paginator, completion: @escaping (Result<Listing>) -> Void) throws -> URLSessionDataTask {
-        guard let request = URLRequest.requestForOAuth(with: baseURL, path:mine.path, parameter:paginator.parameterDictionary, method:"GET", token:token)
+	public func getUserRelatedSubreddit(_ mine: SubredditsMineWhere, paginator: Paginator,  limit: Int? = nil, completion: @escaping (Result<Listing>) -> Void) throws -> URLSessionDataTask {
+		var parameter = paginator.parameterDictionary
+		if let limit = limit {
+			parameter["limit"] = "\(limit)"
+		}
+		guard let request = URLRequest.requestForOAuth(with: baseURL, path:mine.path, parameter:parameter, method:"GET", token:token)
             else { throw ReddiftError.canNotCreateURLRequest as NSError }
         let closure = {(data: Data?, response: URLResponse?, error: NSError?) -> Result<Listing> in
             return Result(from: Response(data: data, urlResponse: response), optional:error)

--- a/framework/OAuth/OAuth2Authorizer.swift
+++ b/framework/OAuth/OAuth2Authorizer.swift
@@ -86,6 +86,7 @@ public class OAuth2Authorizer {
         }
         if let code = parameters["code"], let state = parameters["state"] {
             if code.characters.count > 0 {
+
                 do {
                     try OAuth2Token.getOAuth2Token(code, completion: completion)
                     return true

--- a/reddift.podspec
+++ b/reddift.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
   s.license          = 'MIT'
   s.author           = { "sonson" => "yoshida.yuichi@gmail.com" }
   s.source           = {
-    :git => "https://github.com/sonsongithub/reddift.git",
-    :tag => "#{s.version}",
+    :git => "https://github.com/shusain93/reddift.git",
+    :tag => "v#{s.version}",
     :submodules => true
   }
 


### PR DESCRIPTION
Here's another weird one: when not signed in, reddift doesn't use the oauth subdomain (expected). The problem is the oauth subdomain ALWAYS returns json, regardless of whether you requested it or not. The regular old https://reddit.com/..., however, does not always and you must request it with `.json` explicitly. Some listing methods were not doing this which meant that if you aren't signed in you get back HTML instead of JSON which obviously doesn't work. For example:

Signed out: https://www.reddit.com//by_id/t3_8f6g13 (HTML!!!)

Signed in: https://oauth.reddit.com//by_id/t3_8f6g13 (JSON if sent with creds)

I simply added explicit `.json` to requests where it was forgotten and it now works as expected.