### PR TITLE
Fix a bug where non-logged in accounts can't use certain list methods

### DIFF
--- a/framework/Network/Session+listings.swift
+++ b/framework/Network/Session+listings.swift
@@ -207,7 +207,7 @@ extension Session {
     public func getRandom(_ subreddit: Subreddit? = nil, completion: @escaping (Result<(Listing, Listing)>) -> Void) throws -> URLSessionDataTask {
         var path = "/random"
         if let subreddit = subreddit { path = subreddit.url + "/random" }
-        guard let request = URLRequest.requestForOAuth(with: baseURL, path:path, method:"GET", token:token)
+        guard let request = URLRequest.requestForOAuth(with: baseURL + ".json", path:path, method:"GET", token:token)
             else { throw ReddiftError.canNotCreateURLRequest as NSError }
         let closure = {(data: Data?, response: URLResponse?, error: NSError?) -> Result<(Listing, Listing)> in
             return Result(from: Response(data: data, urlResponse: response), optional:error)
@@ -237,7 +237,7 @@ extension Session {
             //            "sr_detail": "true",
             "show": "all",
         ])
-        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/related/" + thing.id, parameter:parameter, method:"GET", token:token)
+        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/related/" + thing.id + ".json", parameter:parameter, method:"GET", token:token)
             else { throw ReddiftError.canNotCreateURLRequest as NSError }
         let closure = {(data: Data?, response: URLResponse?, error: NSError?) -> Result<(Listing, Listing)> in
             return Result(from: Response(data: data, urlResponse: response), optional:error)
@@ -265,7 +265,7 @@ extension Session {
 //            "sr_detail": "true",
             "show": "all"
         ])
-        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/duplicates/" + thing.id, parameter:parameter, method:"GET", token:token)
+        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/duplicates/" + thing.id + ".json", parameter:parameter, method:"GET", token:token)
             else { throw ReddiftError.canNotCreateURLRequest as NSError }
         let closure = {(data: Data?, response: URLResponse?, error: NSError?) -> Result<(Listing, Listing)> in
             return Result(from: Response(data: data, urlResponse: response), optional:error)
@@ -287,7 +287,7 @@ extension Session {
     @discardableResult
     public func getLinksById(_ links: [Link], completion: @escaping (Result<Listing>) -> Void) throws -> URLSessionDataTask {
         let fullnameList = links.map({ (link: Link) -> String in link.name })
-        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/by_id/" + fullnameList.joined(separator: ","), method:"GET", token:token)
+        guard let request = URLRequest.requestForOAuth(with: baseURL, path:"/by_id/" + fullnameList.joined(separator: ",") + ".json", method:"GET", token:token)
             else { throw ReddiftError.canNotCreateURLRequest as NSError }
         let closure = {(data: Data?, response: URLResponse?, error: NSError?) -> Result<Listing> in
             return Result(from: Response(data: data, urlResponse: response), optional:error)


### PR DESCRIPTION
Here's another weird one: when not signed in, reddift doesn't use the oauth subdomain (expected). The problem is the oauth subdomain ALWAYS returns json, regardless of whether you requested it or not. The regular old https://reddit.com/..., however, does not always and you must request it with `.json` explicitly. Some listing methods were not doing this which meant that if you aren't signed in you get back HTML instead of JSON which obviously doesn't work. For example:

Signed out: https://www.reddit.com//by_id/t3_8f6g13 (HTML!!!)

Signed in: https://oauth.reddit.com//by_id/t3_8f6g13 (JSON if sent with creds)

I simply added explicit `.json` to requests where it was forgotten.